### PR TITLE
Round to one decimal for smoother animation

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -211,7 +211,7 @@
     // Allow for decimal pixel values
     var updatePosition = function(percentage, speed) {
       var value = (speed * (100 * (1 - percentage)));
-      return self.options.round ? Math.round(value) : value;
+      return self.options.round ? Math.round(value * 10) / 10 : value;
     };
 
 


### PR DESCRIPTION
I noticed that the animation begins to stutter when using very slow speeds for Rellax (e.g. `data-rellax-speed="0.25"`). Turning off rounding helps, but causing a drop in performance. I think a good balance (and default) is to round to one decimal.