### PR TITLE
Updated README to include information on "wrapper" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Have any suggestions or feedback? Reach out [@dixonandmoe](https://twitter.com/d
   var rellax = new Rellax('.rellax', {
     speed: -2,
     center: false,
+    wrapper: null,
     round: true,
     vertical: true,
     horizontal: false
@@ -82,6 +83,17 @@ If you want to sort your elements properly in the Z space, you can use the data-
 Horizontal parallax is disabled by default. You can enable it by passing `horizontal: true` in the settings block.
 This feature is intended for panoramic style websites, where users scroll horizontally instead of vertically.
 Note that this can work together at the same time with the default vertical parallax. If you do not want this, pass `vertical: false` in the settings block.
+
+### Custom Wrapper
+By default, the position of parallax elements is determined via the scroll position of the body. Passing in the `wrapper` property will tell Rellax to watch that element instead. 
+```html
+<script>
+  // Set wrapper to .custom-element instead of the body
+  var rellax = new Rellax('.rellax', {
+    wrapper: '.custom-element'
+  });
+</script>
+```
 
 ### Refresh
 ```html


### PR DESCRIPTION
I've added information for the `wrapper` option. Currently, it's not quite clear that you can watch the scroll of a different element instead of the body.