### PR TITLE
Add a new boolean option, relativeToWrapper.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "rellax",
+  "version": "1.6.1",
+  "lockfileVersion": 1
+}

--- a/rellax.js
+++ b/rellax.js
@@ -63,6 +63,7 @@
       speed: -2,
       center: false,
       wrapper: null,
+      relativeToWrapper: false,
       round: true,
       vertical: true,
       horizontal: false,
@@ -154,6 +155,11 @@
       // If the element has the percentage attribute, the posY and posX needs to be
       // the current scroll position's value, so that the elements are still positioned based on HTML layout
       var wrapperPosY = self.options.wrapper ? self.options.wrapper.scrollTop : (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop);
+      // If the option relativeToWrapper is true, use the wrappers offset to top, subtracted from the current page scroll.
+      if (self.options.relativeToWrapper) {
+        var scrollPosY = (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop);
+        wrapperPosY = scrollPosY - self.options.wrapper.offsetTop;
+      }
       var posY = self.options.vertical ? ( dataPercentage || self.options.center ? wrapperPosY : 0 ) : 0;
       var posX = self.options.horizontal ? ( dataPercentage || self.options.center ? (window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft) : 0 ) : 0;
 
@@ -218,6 +224,11 @@
 
       posY = self.options.wrapper ? self.options.wrapper.scrollTop : (document.documentElement || document.body.parentNode || document.body).scrollTop || window.pageYOffset;
       posX = self.options.wrapper ? self.options.wrapper.scrollLeft : (document.documentElement || document.body.parentNode || document.body).scrollLeft || window.pageXOffset;
+      // If option relativeToWrapper is true, use relative wrapper value instead.
+      if (self.options.relativeToWrapper) {
+        var scrollPosY = (document.documentElement || document.body.parentNode || document.body).scrollTop || window.pageYOffset;
+        posY = scrollPosY - self.options.wrapper.offsetTop;
+      }
 
 
       if (oldY != posY && self.options.vertical) {


### PR DESCRIPTION
This addition originates from the need to let movement be relative to a wrapper, rather than scroll position of a wrapper or the scroll position of the window.
We'll use the wrappers vertical offset, and subtract it from the scrollposition, to enable an effect, that feels like the element is relative to its wrapper instead.

Simply a boolean, telling us whether or not it should be relative to the container selected in the wrapper option.