### PR TITLE
Fix refresh() not restarting update()

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -139,12 +139,15 @@
 
       cacheBlocks();
 
+      animate();
+
       // If paused, unpause and set listener for window resizing events
       if (pause) {
         window.addEventListener('resize', init);
         pause = false;
+        // Start the loop
+        update();
       }
-      animate();
     };
 
     // We want to cache the parallax blocks'
@@ -346,9 +349,6 @@
 
     // Init
     init();
-
-    // Start the loop
-    update();
 
     // Allow to recalculate the initial values whenever we want
     self.refresh = init;


### PR DESCRIPTION
I have moved the `update` method inside the `init`. Now calling `refresh` after `destroy` will correctly reinit Rellax.

I'm not sure if `refresh` was intended to reinit rellax, instead of just recalculating positions.
If it is not, I can separate `init` into a method that will calculate positions and method that will set up listeners and loop, if you wish.