### PR TITLE
fix transform style search

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -193,9 +193,10 @@
       var transform = '';
 
       // Check if there's an inline styled transform
-      if (style.indexOf('transform') >= 0) {
+      var searchResult = /transform\s*:/i.exec(style);
+      if (searchResult) {
         // Get the index of the transform
-        var index = style.indexOf('transform');
+        var index = searchResult.index;
 
         // Trim the style to the transform point and get the following semi-colon index
         var trimmedStyle = style.slice(index);


### PR DESCRIPTION
I have noticed, that test center.html does not work properly on elements with `style="transition: transform 10s"`.

Now it should search `transform` only in rule property, not in value