### PR TITLE
Defer update loop if no position is updated

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -309,10 +309,12 @@
         loopId = null;
 
         // Don't animate until we get a position updating event
-        window.addEventListener('resize', deferredUpdate);
-        window.addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
-        window.addEventListener('orientationchange', deferredUpdate);
-        window.addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
+        if (pause === false) {
+          window.addEventListener('resize', deferredUpdate);
+          window.addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
+          window.addEventListener('orientationchange', deferredUpdate);
+          window.addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
+        }
       }
     };
 

--- a/rellax.js
+++ b/rellax.js
@@ -290,9 +290,9 @@
     // Remove event listeners and loop again
     var deferredUpdate = function() {
       window.removeEventListener('resize', deferredUpdate);
-      window.removeEventListener('scroll', deferredUpdate);
       window.removeEventListener('orientationchange', deferredUpdate);
-      window.removeEventListener('touchmove', deferredUpdate);
+      (self.options.wrapper ? self.options.wrapper : window).removeEventListener('scroll', deferredUpdate);
+      (self.options.wrapper ? self.options.wrapper : document).removeEventListener('touchmove', deferredUpdate);
 
       // loop again
       loopId = loop(update);
@@ -309,12 +309,10 @@
         loopId = null;
 
         // Don't animate until we get a position updating event
-        if (pause === false) {
-          window.addEventListener('resize', deferredUpdate);
-          window.addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
-          window.addEventListener('orientationchange', deferredUpdate);
-          window.addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
-        }
+        window.addEventListener('resize', deferredUpdate);
+        window.addEventListener('orientationchange', deferredUpdate);
+        (self.options.wrapper ? self.options.wrapper : window).addEventListener('scroll', deferredUpdate, supportsPassive ? { passive: true } : false);
+        (self.options.wrapper ? self.options.wrapper : document).addEventListener('touchmove', deferredUpdate, supportsPassive ? { passive: true } : false);
       }
     };
 


### PR DESCRIPTION
Browsers will _nag_ you that the "page is running slow", because of the `requestAnimationFrame` running all the time.
This pull request will defer the update if no position is changed, and add the loop again if a `resize`, `scroll`, `orientationchange` or `touchmove` event is triggered.
It will also add `scroll` and `touchmove` events as passive.
