### PR TITLE
Use .getBoundingClientRect().top instead of .offsetTop

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -183,7 +183,7 @@
       // If the option relativeToWrapper is true, use the wrappers offset to top, subtracted from the current page scroll.
       if (self.options.relativeToWrapper) {
         var scrollPosY = (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop);
-        wrapperPosY = scrollPosY - self.options.wrapper.offsetTop;
+        wrapperPosY = scrollPosY - self.options.wrapper.getBoundingClientRect().top;
       }
       var posY = self.options.vertical ? ( dataPercentage || self.options.center ? wrapperPosY : 0 ) : 0;
       var posX = self.options.horizontal ? ( dataPercentage || self.options.center ? self.options.wrapper ? self.options.wrapper.scrollLeft : (window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft) : 0 ) : 0;


### PR DESCRIPTION
.offsetTop only calculates offset to the next relative parent, not the top of the page, which throws off calculations.

Ref #177