### PR TITLE
FIX/rellax.js: introduce document.onreadystatechange to call init()

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -432,7 +432,12 @@
     };
 
     // Init
-    init();
+    document.onreadystatechange = () => {
+      if (document.readyState === 'complete') {
+        // document ready
+        init();
+      }
+    };
 
     // Allow to recalculate the initial values whenever we want
     self.refresh = init;


### PR DESCRIPTION
Trying to solve [Issue #40](https://github.com/dixonandmoe/rellax/issues/40). I'm absolutely not sure if that really solves the bug, as I have used rellax.js only for some hours yet and lacking of experience using it as a library. But it seemed to me, that the `init()` function needs to be called after the document has loaded in order to get more correctish values for the y position 🤔 

See [https://streamable.com/2fwnq](https://streamable.com/2fwnq) for demo