### PR TITLE
Added support for NodeLists and HTMLCollections

### DIFF
--- a/rellax.js
+++ b/rellax.js
@@ -129,7 +129,7 @@
     }
 
     // check if el is a className or a node
-    var elements = typeof el === 'string' ? document.querySelectorAll(el) : [el];
+    var elements = typeof el === 'string' ? document.querySelectorAll(el) : HTMLCollection.prototype.isPrototypeOf(el) || NodeList.prototype.isPrototypeOf(el) ? el : [el];
 
     // Now query selector
     if (elements.length > 0) {


### PR DESCRIPTION
It is currently not possible to initialize with a list of elements. This change will make it possible to use a NodeList (querySelectorAll) or a HTMLCollection (getElementsByClassName / TagName / ...)